### PR TITLE
Feature/heat flux diag

### DIFF
--- a/Makefiles/Makefile.dirac
+++ b/Makefiles/Makefile.dirac
@@ -42,7 +42,7 @@ ifeq ($(USE_FFT),fftw3)
 	FFT_INC = 
 	FFT_DIR = $(FFTW_HOME)
 	FFT_LIB = -lfftw3 #-lfftw3_mpi
-        CPPFLAGS   += -I $(FFTW_INC_DIC)
+        #CPPFLAGS   += -I $(FFTW_INC_DIC)
 endif	
 
 USE_HDF5=

--- a/stella_diagnostics.f90
+++ b/stella_diagnostics.f90
@@ -280,6 +280,7 @@ contains
     use stella_io, only: write_time_nc
     use stella_io, only: write_phi2_nc
     use stella_io, only: write_phi_nc
+    use stella_io, only: write_heat_flux_t_nc ! JFP
     use stella_io, only: write_gvmus_nc
     use stella_io, only: write_gzvs_nc
     use stella_io, only: write_kspectra_nc
@@ -391,6 +392,11 @@ contains
        if (debug) write (*,*) 'stella_diagnostics::write_time_nc'
        call write_time_nc (nout, code_time)
        call write_phi2_nc (nout, phi2)
+
+       if(write_heat_flux_vs_t) then
+          if (debug) write (*,*) 'stella_diagnostics::diagnose_stella::write_heat_flux_t_nc'
+          call write_heat_flux_t_nc (nout, heat_flux) ! JFP, where to get heat_t? heat_flux
+       end if
        if (write_phi_vs_time) then
           if (debug) write (*,*) 'stella_diagnostics::diagnose_stella::write_phi_nc'
           call write_phi_nc (nout, phi_out)

--- a/stella_diagnostics.f90
+++ b/stella_diagnostics.f90
@@ -1143,7 +1143,7 @@ contains
     use vpamu_grids, only: integrate_vmu
     use stella_layouts, only: vmu_lo
     use kt_grids, only: aky, nakx, naky
-    use zgrid, only: nzgrid, ntubes
+    use zgrid, only: nzgrid, ntubes, nztot
     use species, only: nspec
 
     implicit none
@@ -1151,7 +1151,7 @@ contains
     real, dimension (-nzgrid:), intent (in) :: norm
     real, dimension (:), intent (in) :: weights
     complex, dimension (:,:,-nzgrid:,:,vmu_lo%llim_proc:), intent (in) :: gin
-    complex, dimension (:,:,-nzgrid:,:), intent (in) :: fld ! This just specifies where the index begins. Not the size.
+    complex, dimension (:,:,-nzgrid:,:), intent (in) :: fld ! JFP: ky, kx, zed, ntubes
     real, dimension (:,:,-nzgrid:,:,:), intent (in out) :: flxout ! JFP: ky, kx, zed, ntubes, nspec
 
     complex, dimension (:,:,:,:,:), allocatable :: totals
@@ -1159,8 +1159,10 @@ contains
     allocate (totals(naky,nakx,-nzgrid:nzgrid,ntubes,nspec))
 
     call integrate_vmu (gin,weights,totals)
-    flxout = flxout + 0.5*fac*aky*aimag(totals*conjg(fld)) & 
-                       * spread(spread(norm,nakx,2),naky,1)
+    flxout = flxout + 0.5*spread(spread(spread(spread(fac*aky,2,nakx),3,nztot),4,ntubes),5,nspec)*aimag(totals*spread(conjg(fld),5,nspec)) & 
+                       * spread(spread(spread(spread(norm,1,naky),2,nakx),4,ntubes),5,nspec)
+
+    !spread(spread(spread(vperp2(1,:,imu),1,naky),2,nakx),4,ntubes)
 
     deallocate (totals)
 


### PR DESCRIPTION
Diagnostics for writing heat, particle, and momentum fluxes versus time, species, tube, zed, kx, ky. If you could improve upon the following line (1162) of code in stella_diagnostics.f90, it might run faster:

    flxout = flxout + 0.5*spread(spread(spread(spread(fac*aky,2,nakx),3,nztot),4,ntubes),5,nspec)*aimag(totals*spread(conjg(fld),5,nspec)) &
                       * spread(spread(spread(spread(norm,1,naky),2,nakx),4,ntubes),5,nspec)

Since we are spreading these arrays, I fear this might be computationally costly.