### PR TITLE
Adding functionality to save btor in Miller, and btor and bpol in VMEC.

### DIFF
--- a/geo/stella_geometry.f90
+++ b/geo/stella_geometry.f90
@@ -819,14 +819,14 @@ contains
                                               dxdXcoord, dydalpha, exb_nonlin_fac, exb_nonlin_fac_p*exb_nonlin_fac
     write (geometry_unit,*)
 
-    write (geometry_unit,'(14a12)') '# alpha', 'zed', 'zeta', 'bmag', 'gradpar', 'gds2', 'gds21', 'gds22', &
-                                    'gds23', 'gds24', 'gbdrift', 'cvdrift', 'gbdrift0', 'bmag_psi0'
+    write (geometry_unit,'(15a12)') '# alpha', 'zed', 'zeta', 'bmag', 'gradpar', 'gds2', 'gds21', 'gds22', &
+                                    'gds23', 'gds24', 'gbdrift', 'cvdrift', 'gbdrift0', 'bmag_psi0', 'btor'
     do ia = 1, nalpha
        do iz = -nzgrid, nzgrid
-          write (geometry_unit,'(14e12.4)') alpha(ia), zed(iz), zeta(ia,iz), bmag(ia,iz), gradpar(iz), &
+          write (geometry_unit,'(15e12.4)') alpha(ia), zed(iz), zeta(ia,iz), bmag(ia,iz), gradpar(iz), &
                gds2(ia,iz), gds21(ia,iz), gds22(ia,iz), gds23(ia,iz), &
                gds24(ia,iz), gbdrift(ia,iz), cvdrift(ia,iz), gbdrift0(ia,iz), &
-               bmag_psi0(ia,iz)
+               bmag_psi0(ia,iz), btor(iz)
        end do
        write (geometry_unit,*)
     end do

--- a/geo/vmec_interface/test_vmec_to_stella_geometry_interface.f90
+++ b/geo/vmec_interface/test_vmec_to_stella_geometry_interface.f90
@@ -30,6 +30,7 @@ program test_vmec_to_stella_geometry_interface
   real, dimension(nalpha, -nzgrid:nzgrid) :: bmag, gradpar, gds2, gds21, gds22, gds23, gds24, gds25, gds26
   real, dimension (nalpha, -nzgrid:nzgrid) :: gbdrift, gbdrift0, cvdrift, cvdrift0
   real, dimension(nalpha, -nzgrid:nzgrid) :: theta_vmec
+  real, dimension(nalpha, -nzgrid:nzgrid) :: B_sub_zeta, B_sub_theta_vmec
   ! This code uses normalizations in which kxfac is always 1, so kxfac is not presently returned.
 
   !*********************************************************************
@@ -51,7 +52,7 @@ program test_vmec_to_stella_geometry_interface
        sign_toroidal_flux, &
        alpha, zeta, bmag, gradpar, gds2, gds21, gds22, gds23, gds24, gds25, gds26, &
        gbdrift, gbdrift0, cvdrift, cvdrift0, &
-       theta_vmec)
+       theta_vmec, B_sub_zeta, B_sub_theta_vmec)
 
   print *,"-------------- Input parameters ------------------"
   print *,"vmec_filename: ",trim(vmec_filename)

--- a/geo/vmec_interface/vmec_to_stella_geometry_interface.f90
+++ b/geo/vmec_interface/vmec_to_stella_geometry_interface.f90
@@ -191,7 +191,7 @@ contains
        alpha, zeta, bmag, gradpar_zeta, grad_alpha_grad_alpha, &
        grad_alpha_grad_psi, grad_psi_grad_psi, gds23, gds24, gds25, gds26, &
        gbdrift_alpha, gbdrift0_psi, cvdrift_alpha, cvdrift0_psi, &
-       theta_vmec)
+       theta_vmec, B_sub_zeta, B_sub_theta_vmec)
 
     use fzero_mod, only: fzero
 
@@ -286,6 +286,8 @@ contains
 !    real, dimension (:,-nzgrid:), intent (out) :: gbdrift, gbdrift0, cvdrift, cvdrift0
     real, dimension (:,-nzgrid:), intent (out) :: gbdrift0_psi, cvdrift0_psi
 
+    real, dimension (:,-nzgrid:), intent (out) :: B_sub_theta_vmec, B_sub_zeta
+
     !*********************************************************************
     ! Variables used internally by this subroutine
     !*********************************************************************
@@ -312,7 +314,8 @@ contains
     real, dimension(:,:), allocatable :: d_X_d_theta_vmec, d_X_d_zeta, d_X_d_s
     real, dimension(:,:), allocatable :: d_Y_d_theta_vmec, d_Y_d_zeta, d_Y_d_s
     real, dimension(:,:), allocatable :: d_Lambda_d_theta_vmec, d_Lambda_d_zeta, d_Lambda_d_s
-    real, dimension(:,:), allocatable :: B_sub_s, B_sub_theta_vmec, B_sub_zeta
+    !real, dimension(:,:), allocatable :: B_sub_s, B_sub_theta_vmec, B_sub_zeta
+    real, dimension(:,:), allocatable :: B_sub_s
     real, dimension(:,:), allocatable :: B_sup_theta_vmec, B_sup_zeta
     real, dimension(:), allocatable :: d_B_d_s_mnc, d_B_d_s_mns
     real, dimension(:), allocatable :: d_R_d_s_mnc, d_R_d_s_mns
@@ -735,6 +738,8 @@ contains
     gbdrift0_psi = 0
     cvdrift_alpha = 0
     cvdrift0_psi = 0
+    B_sub_theta_vmec = 0
+    B_sub_zeta = 0
 
     allocate(B(nalpha,-nzgrid:nzgrid))
     allocate(temp2D(nalpha,-nzgrid:nzgrid))
@@ -753,8 +758,8 @@ contains
     allocate(d_Lambda_d_zeta(nalpha,-nzgrid:nzgrid))
     allocate(d_Lambda_d_s(nalpha,-nzgrid:nzgrid))
     allocate(B_sub_s(nalpha,-nzgrid:nzgrid))
-    allocate(B_sub_theta_vmec(nalpha,-nzgrid:nzgrid))
-    allocate(B_sub_zeta(nalpha,-nzgrid:nzgrid))
+    !allocate(B_sub_theta_vmec(nalpha,-nzgrid:nzgrid))
+    !allocate(B_sub_zeta(nalpha,-nzgrid:nzgrid))
     allocate(B_sup_theta_vmec(nalpha,-nzgrid:nzgrid))
     allocate(B_sup_zeta(nalpha,-nzgrid:nzgrid))
 
@@ -1452,8 +1457,8 @@ contains
     deallocate(d_Lambda_d_zeta)
     deallocate(d_Lambda_d_s)
     deallocate(B_sub_s)
-    deallocate(B_sub_theta_vmec)
-    deallocate(B_sub_zeta)
+    !deallocate(B_sub_theta_vmec)
+    !deallocate(B_sub_zeta)
     deallocate(B_sup_theta_vmec)
     deallocate(B_sup_zeta)
 


### PR DESCRIPTION
Useful for writing out the toroidal and poloidal components of the magnetic field. Appended the new magnetic field components to the final column(s) in .geometry and vmec.geo files so that (hopefully) does not interfere with prior postprocessing scripts.