### PR TITLE
Add basic Github Actions, only compilation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,38 @@
+name: Tests
+on: [push, pull_request]
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  standard_tests:
+    runs-on: ubuntu-latest
+    env:
+      OMPI_MCA_rmaps_base_oversubscribe: yes
+      MPIRUN: mpiexec -np
+    steps:
+      - name: Install dependencies
+        run: sudo apt update &&
+             sudo apt install -y
+                 gfortran
+                 make
+                 libfftw3-dev
+                 libnetcdf-dev
+                 libnetcdff-dev
+                 netcdf-bin
+                 python3
+                 python3-pip
+                 openmpi-bin
+                 libopenmpi-dev
+
+      - name: System information
+        run: |
+          cat /etc/*release
+          gfortran --version
+          nf-config --all
+
+      - uses: actions/checkout@v2
+
+      - name: Build stella
+        run: ./scripts/ci_build_and_run.sh

--- a/scripts/ci_build_and_run.sh
+++ b/scripts/ci_build_and_run.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -ex
+
+export GK_SYSTEM=gnu_ubuntu
+make -I Makefiles -j2


### PR DESCRIPTION
This adds the minimal useful Github Action that just compiles stella. This could be merged as-is, or we could wait until there are some tests.

I've split this into two files: the Actions YAML file (`tests.yml`) which defines the action, and a shell script that just runs `make`. This split will help keep things clean when it starts getting more complicated.
